### PR TITLE
fix: pull version from package.json so that -V responds correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,14 @@ const sha256 = (data) => {
     return createHash('sha256').update(data).digest('hex')
 }
 
+const packageJson = require('../package.json');
+
 const program = new Command();
 
 console.log(figlet.textSync("FUCK YEA"));
 
 program
-    .version("1.0.0")
+    .version(packageJson.version)
     .description("A command line interface for working with Antelope Smart Contracts")
     .action(() => {
 


### PR DESCRIPTION
This pull request fixes the issue where the command 'fuckyea -V' displays the wrong version.

By pulling the version from 'package.json', the CLI now correctly reflects version 1.3.0, as specified in the package file.

This change addresses and closes https://github.com/nsjames/fuckyea/issues/15.